### PR TITLE
fix vision-explanation-methods package pip install due to missing init file

### DIFF
--- a/python/vision_explanation_methods/__init__.py
+++ b/python/vision_explanation_methods/__init__.py
@@ -4,7 +4,7 @@
 
 """Module for creating explanations for vision models.
 """
-from .vision_explanation_methods.version import name, version
+from .version import name, version
 
 __name__ = name
 __version__ = version

--- a/python/vision_explanation_methods/version.py
+++ b/python/vision_explanation_methods/version.py
@@ -1,5 +1,5 @@
 name = 'vision_explanation_methods'
 _major = '0'
 _minor = '0'
-_patch = '1'
+_patch = '2'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

The vision-explanation-methods package pip install was failing because the init file was in the wrong location.  The init file should be in package directory instead of top-level python directory where setup.py is defined.  Local editable install mode does not need to use the init files hence it was still working fine before we tried to use this as a pip installable package from url.
This PR fixes the file location to make the package pip installable.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added tests for all changes.
- [ ] Documentation was updated if it was needed.
