### PR TITLE
Version Update: Moving Wrapping Outside of Vision Explanation Methods

### DIFF
--- a/python/vision_explanation_methods/version.py
+++ b/python/vision_explanation_methods/version.py
@@ -3,5 +3,5 @@
 name = 'vision_explanation_methods'
 _major = '0'
 _minor = '0'
-_patch = '4'
+_patch = '3'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/python/vision_explanation_methods/version.py
+++ b/python/vision_explanation_methods/version.py
@@ -3,5 +3,5 @@
 name = 'vision_explanation_methods'
 _major = '0'
 _minor = '0'
-_patch = '3'
+_patch = '4'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
Thir PR updates the vision_explanation_methods package with the changes from this PR:
https://github.com/microsoft/vision-explanation-methods/pull/18

This change essentially moves wrapping outside of Vision Explanation Methods, and uses the new wrapper from ml-wrappers
