### PR TITLE
fix release script typo causing error: a step cannot have both the uses and run keys

### DIFF
--- a/.github/workflows/release-vision-explanation-methods.yml
+++ b/.github/workflows/release-vision-explanation-methods.yml
@@ -27,7 +27,7 @@ jobs:
           auto-update-conda: true
           python-version: 3.8
 
-        name: Install pytorch
+      - name: Install pytorch
         shell: bash -l {0}
         run: |
           conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch -c conda-forge --strict-channel-priority


### PR DESCRIPTION
## Description

Fix typo error in release script causing it to fail to run with error:

```
a step cannot have both the `uses` and `run` keys
```

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added tests for all changes.
- [ ] Documentation was updated if it was needed.
