### PR TITLE
Dpv2 testing: Vision_Explanation_Methods Fixes

### DIFF
--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -162,7 +162,7 @@ def get_drise_saliency_map(
     if num_detections == 0:  # If no objects have been detected...
         fail = Image.new('RGB', (100, 100))
         fail = fail.save(savename)
-        return None, None
+        return None, None, None
 
     label_list = []
     fig_list = []

--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -132,12 +132,12 @@ def get_drise_saliency_map(
     test_image = Image.open(image_open_pointer).convert('RGB')
 
     detections = model.predict(
-        T.ToTensor()(test_image).unsqueeze(0).repeat(2, 1, 1, 1).to(device))
+        T.ToTensor()(test_image).unsqueeze(0).to(device))
 
     saliency_scores = drise.DRISE_saliency(
         model=model,
         # Repeated the tensor to test batching
-        image_tensor=T.ToTensor()(test_image).repeat(2, 1, 1, 1).to(device),
+        image_tensor=T.ToTensor()(test_image).unsqueeze(0).to(device),
         target_detections=detections,
         # This is how many masks to run -
         # more is slower but gives higher quality mask.
@@ -161,8 +161,7 @@ def get_drise_saliency_map(
     num_detections = len(saliency_scores)
 
     if num_detections == 0:  # If no objects have been detected...
-        fail = Image.open(os.path.join("python", "vision_explanation_methods",
-                                       "images", "notfound.jpg"))
+        fail = Image.new('RGB', (100, 100))
         fail = fail.save(savename)
         return None, None
 

--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -1,6 +1,5 @@
 """Method for generating saliency maps for object detection models."""
 
-import os
 from io import BytesIO
 from typing import Optional, Tuple
 

--- a/python/vision_explanation_methods/explanations/drise.py
+++ b/python/vision_explanation_methods/explanations/drise.py
@@ -127,8 +127,8 @@ def compute_affinity_scores(
     :rtype: Tensor of shape D, where D is number of base detections
     """
     score_matrix = compute_affinity_matrix(base_detections, masked_detections)
-    if not (score_matrix.numel()):
-        return torch.empty((1, 1), dtype=torch.int64)
+    # if not (score_matrix.numel()):
+    #     return torch.empty((1, 1), dtype=torch.int64)
     return torch.max(score_matrix, dim=1)[0]
 
 

--- a/python/vision_explanation_methods/explanations/drise.py
+++ b/python/vision_explanation_methods/explanations/drise.py
@@ -127,6 +127,7 @@ def compute_affinity_scores(
     :rtype: Tensor of shape D, where D is number of base detections
     """
     score_matrix = compute_affinity_matrix(base_detections, masked_detections)
+
     return torch.max(score_matrix, dim=1)[0]
 
 

--- a/python/vision_explanation_methods/explanations/drise.py
+++ b/python/vision_explanation_methods/explanations/drise.py
@@ -127,7 +127,8 @@ def compute_affinity_scores(
     :rtype: Tensor of shape D, where D is number of base detections
     """
     score_matrix = compute_affinity_matrix(base_detections, masked_detections)
-
+    if not (score_matrix.numel()):
+        return torch.empty((1, 1), dtype=torch.int64)
     return torch.max(score_matrix, dim=1)[0]
 
 

--- a/python/vision_explanation_methods/explanations/drise.py
+++ b/python/vision_explanation_methods/explanations/drise.py
@@ -127,8 +127,6 @@ def compute_affinity_scores(
     :rtype: Tensor of shape D, where D is number of base detections
     """
     score_matrix = compute_affinity_matrix(base_detections, masked_detections)
-    # if not (score_matrix.numel()):
-    #     return torch.empty((1, 1), dtype=torch.int64)
     return torch.max(score_matrix, dim=1)[0]
 
 


### PR DESCRIPTION
In the process of testing the object detection scenario E2E, a few optimizations to the vision_explanation_methods code are needed:
1. remove repetition of computation 
2. account for the possibility of no objects being found