### PR TITLE
fix - correct the usage of get_drise_saliency_map() api in the tutorial notebook and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ To generate saliency maps, import the package and run:
 ```
 res = DRISE_runner.get_drise_saliency_map(
     imagelocation: str,
-    model: Optional[object],
-    modellocation: Optional[str],
+    model: Optional[object],    
     numclasses: int,
     savename: str,
     nummasks: int=25,

--- a/notebooks/Microsoft_Object_Detection_Explainability_D_RISE_Tutorial.ipynb
+++ b/notebooks/Microsoft_Object_Detection_Explainability_D_RISE_Tutorial.ipynb
@@ -715,6 +715,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "VXx0sJ3TnJP2"
@@ -726,8 +727,7 @@
         "---\n",
         "\n",
         "    imagelocation: str - path of the input image\n",
-        "    model: Optional[object] - PyTorch model (default: Faster R-CNN)\n",
-        "    modellocation: Optional[str] - path of the model weights\n",
+        "    model: Optional[object] - PyTorch model (default: Faster R-CNN)    \n",
         "    numclasses: int - number of classes model predicts\n",
         "    savename: str - name of output saliency map image\n",
         "    nummasks: int=25 - number of masks to use for saliency\n",
@@ -761,7 +761,13 @@
       },
       "outputs": [],
       "source": [
-        "res = dr.get_drise_saliency_map('odFridgeObjects/images/17.jpg', None, 'Recycling_finetuned_FastRCNN.pt', 5, 'outputmap.jpg')"
+        "res = dr.get_drise_saliency_map(imagelocation='odFridgeObjects/images/17.jpg',\n",
+        "                                    model=PytorchFasterRCNNWrapper(\n",
+        "                                          model=model,\n",
+        "                                          number_of_classes=5),\n",
+        "                                    numclasses=5,\n",
+        "                                    savename='outputmap.jpg',\n",
+        "                                    max_figures=2)"
       ]
     }
   ],
@@ -781,7 +787,7 @@
     },
     "language_info": {
       "name": "python",
-      "version": "3.10.9 (tags/v3.10.9:1dd9be6, Dec  6 2022, 20:01:21) [MSC v.1934 64 bit (AMD64)]"
+      "version": "3.9.16"
     },
     "vscode": {
       "interpreter": {


### PR DESCRIPTION
## Description

Two issues:

1) The tutorial notebook is using the `get_drise_saliency_map` incorrectly.

After running & reading the source code I figured out there is no parameter ` modellocation: Optional[str]` but is used in the notebook as well as specified in the notebook. Perhaps it used to exist earlier.

2) If the model is not specified then the API uses FastRCNN model which has 87 classes. The purpose of the tutorial notebook is to use either a pretrained model (5 classes) or finetune it in the notebook. This means that specifying None for model must use numclasses = 87 and not 5. This adds to more confusion.

Hence to be explicit I am using 

```
model=PytorchFasterRCNNWrapper(
                                          model=model,
                                          number_of_classes=5),
                                    numclasses=5,
```

It also demonstrates how the wrapper should be used.

## Checklist

- [ ] I have added tests for all changes.
- [x ] Documentation was updated if it was needed.
