### PR TITLE
Clearing Image Plot (bug fix)

### DIFF
--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -187,5 +187,6 @@ def get_drise_saliency_map(
         )
 
         fig.savefig(savename+str(i)+IMAGE_TYPE)
+        fig.clear()
         fig_list.append(fig)
     return fig_list, savename, label_list


### PR DESCRIPTION
This PR fixes a bug in the RAI dashboard experience in which the first image was being overwritten. The issue was that the matplotlib plt object was not being cleared after use. 

Successful run: https://ml.azure.com/experiments/id/615e87b4-2967-4dae-8ad2-9929f3fa2d30/runs/jolly_kettle_dnfl9hjgcl?wsid=/subscriptions/a75ae43f-9f72-4699-ba66-d3a173cfe082/resourceGroups/ilmatdpv2rg3/providers/Microsoft.MachineLearningServices/workspaces/ilmatdpv2ws3&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#