### PR TITLE
Unit Test Fix

### DIFF
--- a/tests/test_vision_explanation.py
+++ b/tests/test_vision_explanation.py
@@ -176,7 +176,7 @@ def test_vision_explain_loadmodel():
                                      model=PytorchDRiseWrapper(
                                           model=model,
                                           number_of_classes=87),
-                                     numclasses=5, 
+                                     numclasses=5,
                                      savename=savepath2,
                                      max_figures=2)
 

--- a/tests/test_vision_explanation.py
+++ b/tests/test_vision_explanation.py
@@ -175,7 +175,7 @@ def test_vision_explain_loadmodel():
     res2 = dr.get_drise_saliency_map(imagelocation=imgpath2,
                                      model=PytorchDRiseWrapper(
                                           model=model,
-                                          number_of_classes=87),
+                                          number_of_classes=5),
                                      numclasses=5,
                                      savename=savepath2,
                                      max_figures=2)

--- a/tests/test_vision_explanation.py
+++ b/tests/test_vision_explanation.py
@@ -173,7 +173,9 @@ def test_vision_explain_loadmodel():
     # run the main function for saliency map generation
     # in the case of just a single item in photo
     res2 = dr.get_drise_saliency_map(imagelocation=imgpath2,
-                                     model=None,
+                                     model=PytorchDRiseWrapper(
+                                          model=model,
+                                          number_of_classes=87),
                                      numclasses=87,
                                      savename=savepath2,
                                      max_figures=2)


### PR DESCRIPTION
This PR fixes a transient failure on unit test test_vision_explain_loadmodel. For reference, here is a successful run on the first try: https://github.com/microsoft/vision-explanation-methods/actions/runs/4809887739/jobs/8561746052?pr=35

The crux of this issue was that the drise call in the test_vision_explain_loadmodel was not actually loading the model, and instead was passing None as the model value. 