### PR TITLE
Returning b64encoded str from drise runner

### DIFF
--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -137,9 +137,6 @@ def get_drise_saliency_map(
 
     test_image = Image.open(image_open_pointer).convert('RGB')
 
-    detections = model.predict(
-        T.ToTensor()(test_image).unsqueeze(0).to(device))
-
     print("detections_vision expl methods")
     print(detections)
     print("img_vision expl methods")
@@ -195,6 +192,8 @@ def get_drise_saliency_map(
 
     img_index = 0
 
+    print(saliency_scores)
+
     # Filter out saliency scores containing nan values
     saliency_scores = [saliency_scores[img_index][i]
                        for i in range(len(saliency_scores[img_index]))
@@ -205,9 +204,7 @@ def get_drise_saliency_map(
     num_detections = len(saliency_scores)
     if num_detections == 0:
         print("No detections found. Saving empty figure.")
-        fail = Image.new('RGB', (100, 100))
-        fail = fail.save(savename)
-        return None, None, None
+        raise ValueError()
 
     label_list = []
     fig_list = []
@@ -232,19 +229,11 @@ def get_drise_saliency_map(
             use_pyplot=False
         )
 
-        fig.savefig(savename+str(i)+IMAGE_TYPE)
-        fig.clear()
-
-        # for debugging
-        # flike = io.BytesIO()
-        # fig.savefig(flike)
-        # b64 = base64.b64encode(flike.getvalue()).decode()
-        # print(b64)
-
-        image = get_image_from_path(savename+str(i) + ".jpg", "RGB")
-        jpg_img = cv2.imencode('.jpg', image)
-        b64_string = base64.b64encode(jpg_img[1]).decode('utf-8')
-        print("vizexplmethods str: " + b64_string)
+        stream = io.BytesIO()
+        plt.savefig(stream, format='jpg')
+        stream.seek(0)
+        b64_string = base64.b64encode(stream.read()).decode()
         fig_list.append(b64_string)
+        fig.clear()
 
     return fig_list, savename, label_list

--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -12,7 +12,7 @@ import requests
 import torch
 import torchvision
 from captum.attr import visualization as viz
-from ml_wrappers.model.image_model_wrapper import (MLflowDRiseWrapFper,
+from ml_wrappers.model.image_model_wrapper import (MLflowDRiseWrapper,
                                                    PytorchDRiseWrapper)
 from PIL import Image
 from torchvision import transforms as T

--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -4,9 +4,6 @@ import base64
 from io import BytesIO
 from typing import Optional, Tuple
 
-import cv2
-import io
-import base64
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy
@@ -21,7 +18,6 @@ from PIL import Image
 from torchvision import transforms as T
 from torchvision.models import detection
 from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
-from responsibleai_vision.utils.image_reader import get_image_from_path
 
 from .explanations import drise
 
@@ -137,8 +133,6 @@ def get_drise_saliency_map(
 
     test_image = Image.open(image_open_pointer).convert('RGB')
 
-    print("detections_vision expl methods")
-    print(detections)
     print("img_vision expl methods")
     print(str(test_image))
     if isinstance(model, MLflowDRiseWrapper):
@@ -173,7 +167,7 @@ def get_drise_saliency_map(
         detections = model.predict(img_input)
 
         print(str(detections))
-        
+
         saliency_scores = drise.DRISE_saliency(
             model=model,
             # Repeated the tensor to test batching
@@ -231,7 +225,7 @@ def get_drise_saliency_map(
             use_pyplot=False
         )
 
-        stream = io.BytesIO()
+        stream = BytesIO()
         plt.savefig(stream, format='jpg')
         stream.seek(0)
         b64_string = base64.b64encode(stream.read()).decode()

--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -12,7 +12,7 @@ import requests
 import torch
 import torchvision
 from captum.attr import visualization as viz
-from ml_wrappers.model.image_model_wrapper import (MLflowDRiseWrapper,
+from ml_wrappers.model.image_model_wrapper import (MLflowDRiseWrapFper,
                                                    PytorchDRiseWrapper)
 from PIL import Image
 from torchvision import transforms as T
@@ -190,7 +190,7 @@ def get_drise_saliency_map(
 
     num_detections = len(saliency_scores)
     if num_detections == 0:
-        raise ValueError()
+        raise ValueError("No detections found")
 
     label_list = []
     fig_list = []

--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -219,6 +219,7 @@ def get_drise_saliency_map(
         stream.seek(0)
         b64_string = base64.b64encode(stream.read()).decode()
         fig_list.append(b64_string)
+        fig.savefig(savename+str(i)+IMAGE_TYPE)
         fig.clear()
 
     return fig_list, savename, label_list

--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -139,7 +139,7 @@ def get_drise_saliency_map(
 
     detections = model.predict(
         T.ToTensor()(test_image).unsqueeze(0).to(device))
-    
+
     print("detections_vision expl methods")
     print(detections)
     print("img_vision expl methods")

--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -133,8 +133,6 @@ def get_drise_saliency_map(
 
     test_image = Image.open(image_open_pointer).convert('RGB')
 
-    print("img_vision expl methods")
-    print(str(test_image))
     if isinstance(model, MLflowDRiseWrapper):
         x, y = test_image.size
         imgio = BytesIO()
@@ -166,8 +164,6 @@ def get_drise_saliency_map(
 
         detections = model.predict(img_input)
 
-        print(str(detections))
-
         saliency_scores = drise.DRISE_saliency(
             model=model,
             # Repeated the tensor to test batching
@@ -184,30 +180,22 @@ def get_drise_saliency_map(
             verbose=True  # Turns progress bar on/off.
         )
 
-    print("calculated saliency scores")
-
     img_index = 0
-
-    print(saliency_scores)
 
     # Filter out saliency scores containing nan values
     saliency_scores = [saliency_scores[img_index][i]
                        for i in range(len(saliency_scores[img_index]))
                        if not torch.isnan(
                        saliency_scores[img_index][i]['detection']).any()]
-    print("filtered")
-    print(saliency_scores)
 
     num_detections = len(saliency_scores)
     if num_detections == 0:
-        print("No detections found. Saving empty figure.")
         raise ValueError()
 
     label_list = []
     fig_list = []
     for i in range((max_figures if num_detections > max_figures
                     else num_detections)):
-        print("entering loop")
         fig, ax = plt.subplots(1, 1, figsize=(10, 10))
         label = int(torch.argmax(detections[img_index].class_scores[i]))
         label_list.append(label)

--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -172,6 +172,8 @@ def get_drise_saliency_map(
 
         detections = model.predict(img_input)
 
+        print(str(detections))
+        
         saliency_scores = drise.DRISE_saliency(
             model=model,
             # Repeated the tensor to test batching

--- a/python/vision_explanation_methods/DRISE_runner.py
+++ b/python/vision_explanation_methods/DRISE_runner.py
@@ -196,6 +196,7 @@ def get_drise_saliency_map(
                        if not torch.isnan(
                        saliency_scores[img_index][i]['detection']).any()]
     print("filtered")
+    print(saliency_scores)
 
     num_detections = len(saliency_scores)
     if num_detections == 0:

--- a/python/vision_explanation_methods/version.py
+++ b/python/vision_explanation_methods/version.py
@@ -2,6 +2,6 @@
 
 name = 'vision_explanation_methods'
 _major = '0'
-_minor = '0'
-_patch = '5'
+_minor = '1'
+_patch = '1'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/python/vision_explanation_methods/version.py
+++ b/python/vision_explanation_methods/version.py
@@ -2,6 +2,6 @@
 
 name = 'vision_explanation_methods'
 _major = '0'
-_minor = '1'
-_patch = '1'
+_minor = '0'
+_patch = '6'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/tests/test_vision_explanation.py
+++ b/tests/test_vision_explanation.py
@@ -8,7 +8,6 @@ import logging
 import os
 import urllib.request as request_file
 
-import matplotlib.pyplot as plt
 import vision_explanation_methods.DRISE_runner as dr
 from ml_wrappers.model.image_model_wrapper import PytorchDRiseWrapper
 

--- a/tests/test_vision_explanation.py
+++ b/tests/test_vision_explanation.py
@@ -64,9 +64,8 @@ def test_vision_explain_preloaded():
     # assert that result is a tuple of figure, location, and labels.
     assert (len(res) == 3)
 
-    # assert that first element in result is a figure.
-    fig, axis = plt.subplots(2, 2)
-    assert (isinstance(res[0][0], type(fig)))
+    # assert that first element in result is a string
+    assert (isinstance(res[0][0], type(str)))
 
     # assert that figure has been saved in proper location.
     assert (os.path.exists(res[1]+"0"+".jpg"))
@@ -93,9 +92,8 @@ def test_vision_explain_preloaded():
     # assert that result is a tuple of figure, location, and labels.
     assert (len(res2) == 3)
 
-    # assert that first element in result is a figure.
-    fig, axis = plt.subplots(2, 2)
-    assert (isinstance(res2[0][0], type(fig)))
+    # assert that first element in result is a string
+    assert (isinstance(res2[0][0], type(str)))
 
     # assert that figure has been saved in proper location.
     assert (os.path.exists(res2[1]+"0"+".jpg"))
@@ -152,9 +150,8 @@ def test_vision_explain_loadmodel():
     # assert that result is a tuple of figure, location, and labels.
     assert (len(res) == 3)
 
-    # assert that first element in result is a figure.
-    fig, axis = plt.subplots(2, 2)
-    assert (isinstance(res[0][0], type(fig)))
+    # assert that first element in result is a string
+    assert (isinstance(res[0][0], type(str)))
 
     # assert that figure has been saved in proper location.
     assert (os.path.exists(res[1]+"0"+".jpg"))
@@ -183,9 +180,8 @@ def test_vision_explain_loadmodel():
     # assert that result is a tuple of figure, location, and labels.
     assert (len(res2) == 3)
 
-    # assert that first element in result is a figure.
-    fig, axis = plt.subplots(2, 2)
-    assert (isinstance(res2[0][0], type(fig)))
+    # assert that first element in result is a string
+    assert (isinstance(res2[0][0], type(str)))
 
     # assert that figure has been saved in proper location.
     assert (os.path.exists(res2[1]+"0"+".jpg"))

--- a/tests/test_vision_explanation.py
+++ b/tests/test_vision_explanation.py
@@ -64,7 +64,7 @@ def test_vision_explain_preloaded():
     assert (len(res) == 3)
 
     # assert that first element in result is a string
-    assert (isinstance(res[0][0], type(str)))
+    assert (isinstance(res[0][0], str))
 
     # assert that figure has been saved in proper location.
     assert (os.path.exists(res[1]+"0"+".jpg"))
@@ -92,7 +92,7 @@ def test_vision_explain_preloaded():
     assert (len(res2) == 3)
 
     # assert that first element in result is a string
-    assert (isinstance(res2[0][0], type(str)))
+    assert (isinstance(res2[0][0], str))
 
     # assert that figure has been saved in proper location.
     assert (os.path.exists(res2[1]+"0"+".jpg"))
@@ -150,7 +150,7 @@ def test_vision_explain_loadmodel():
     assert (len(res) == 3)
 
     # assert that first element in result is a string
-    assert (isinstance(res[0][0], type(str)))
+    assert (isinstance(res[0][0], str))
 
     # assert that figure has been saved in proper location.
     assert (os.path.exists(res[1]+"0"+".jpg"))
@@ -180,7 +180,7 @@ def test_vision_explain_loadmodel():
     assert (len(res2) == 3)
 
     # assert that first element in result is a string
-    assert (isinstance(res2[0][0], type(str)))
+    assert (isinstance(res2[0][0], str))
 
     # assert that figure has been saved in proper location.
     assert (os.path.exists(res2[1]+"0"+".jpg"))

--- a/tests/test_vision_explanation.py
+++ b/tests/test_vision_explanation.py
@@ -173,7 +173,9 @@ def test_vision_explain_loadmodel():
     # run the main function for saliency map generation
     # in the case of just a single item in photo
     res2 = dr.get_drise_saliency_map(imagelocation=imgpath2,
-                                     model=None,
+                                     model=PytorchDRiseWrapper(
+                                          model=model,
+                                          number_of_classes=87),
                                      numclasses=87,
                                      savename=savepath2,
                                      max_figures=2)


### PR DESCRIPTION
This PR changes the return type of drise runner from a matplotlib figure list, ... to a base64 encoded string list of images. 

Previously, there was a bug in the figure_list return value because we were clearing the figure plot before actually returning it. 

This PR gives greater flexibility to users: they can read in the figure from their local directory, or they can use the pre-encoded string from the return value. 