### PR TITLE
Error Labeling

### DIFF
--- a/python/vision_explanation_methods/error_labeling/error_labeling.py
+++ b/python/vision_explanation_methods/error_labeling/error_labeling.py
@@ -1,0 +1,173 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Defines the Error Labeling Manager class."""
+
+import cv2
+import base64
+import io
+import json
+import pickle
+import warnings
+from pathlib import Path
+from typing import Any, List, Optional
+import torch
+import torchmetrics
+import torchmetrics.functional as metrics
+import torchvision
+from torch import Tensor
+
+import matplotlib.pyplot as pl
+import numpy as np
+import pandas as pd
+import shap
+from ml_wrappers import wrap_model
+from responsibleai._interfaces import ModelExplanationData
+from responsibleai._internal.constants import ExplainerManagerKeys as Keys
+from responsibleai._internal.constants import (ListProperties, ManagerNames,
+                                               Metadata)
+from responsibleai._tools.shared.state_directory_management import \
+    DirectoryManager
+from responsibleai.exceptions import UserConfigValidationException
+from responsibleai.managers.base_manager import BaseManager
+from responsibleai_vision.common.constants import (CommonTags,
+                                                   ExplainabilityDefaults,
+                                                   ExplainabilityLiterals,
+                                                   MLFlowSchemaLiterals,
+                                                   ModelTask,
+                                                   XAIPredictionLiterals)
+from responsibleai_vision.utils.image_reader import (
+    get_base64_string_from_path, get_image_from_path, is_automl_image_model)
+from shap.plots import colors
+from shap.utils._legacy import kmeans
+from vision_explanation_methods.DRISE_runner import get_drise_saliency_map
+from ml_wrappers.model.image_model_wrapper import (PytorchDRiseWrapper,
+                                                   MLflowDRiseWrapper)
+from PIL import Image, ImageDraw, ImageFont
+from enum import Enum
+
+LABELS = 'labels'
+
+
+class ErrorLabelType(Enum):
+    """
+    Enum providing types of error labels.
+
+    If none, then the detection is not an error. It is a
+    correct prediction.
+    """
+    # the gt doesn't have a corresponding detection
+    MISSING = "missing"
+
+    # the model predicted detections, but there was nothing there
+    BACKGROUND = "background"
+
+    # the predicted class is correct, bounding box is not
+    LOCALIZATION = "localization"
+
+    # the predicted class is incorrect, the bounding box is correct
+    CLASS_NAME = "class_name"
+
+    # both the predicted class and bounding box are incorrect
+    BOTH = "both"
+
+    # the predicted class is correct, the bounding box is correct, but
+    # the iou score is lower than another detection
+    DUPLICATE_DETECTION = "duplicate_detection"
+
+    MATCH = "match"
+
+
+class ErrorLabeling(BaseManager):
+    """Defines a wrapper class of Error Labeling for vision scenario.
+    Only supported for object detection at this point.
+    """
+    def __init__(self,
+                 task_type: str,
+                 pred_y: str,
+                 true_y: str,
+                 iou_threshold: float = 0.5):
+        """Creates an ErrorLabeling object.
+
+        :param model: The model to explain.
+            A model that implements sklearn.predict or sklearn.predict_proba
+            or function that accepts a 2d ndarray.
+        :type model: object
+        :param evaluation_examples: A matrix of feature vector
+            examples (# examples x # features) on which to explain the
+            model's output, with an additional label column.
+        :type evaluation_examples: pandas.DataFrame
+        :param target_column: The name of the label column.
+        :type target_column: str
+        :param task_type: The task to run.
+        :type task_type: str
+        :param classes: Class names as a list of strings.
+            The order of the class names should match that of the model
+            output. Only required if explaining classifier.
+        :type classes: list
+        :param image_mode: The mode to open the image in.
+            See pillow documentation for all modes:
+            https://pillow.readthedocs.io/en/stable/handbook/concepts.html
+        :type image_mode: str
+        """
+        self._is_run = False
+        self._is_added = False
+        self._task_type = task_type
+        self._pred_y = pred_y
+        self._true_y = true_y
+        self._iou_threshold = iou_threshold
+
+        self._match_matrix = [[None for i in range(len(pred_y))] for i in range(len(true_y))]
+
+    def compute(self, **kwargs):
+        """Compute the error analysis data.
+
+        :param kwargs: The keyword arguments to pass to the compute method.
+            Note that this method does not take any arguments currently.
+        :type kwargs: dict
+        """
+        if not self._is_added:
+            self.add()
+
+        for detect_index in range(len(self._pred_y)):
+            detect = self._pred_y[detect_index]
+            matched = False
+            background = True
+            for gt_index in range(len(self._true_y)):
+                gt = self._true_y[gt_index]
+                iou_score = torchvision.ops.box_iou(Tensor(detect[1:5]).unsqueeze(0),
+                                                    Tensor(gt[1:5]).unsqueeze(0))
+                if iou_score > 0:
+                    background = False
+                if (self._iou_threshold <= iou_score):
+                    # the detection and ground truth bb's must be overlapping
+                    if detect[0] != gt[0]:
+                        # the bb's line up, but labels do not
+                        matched = True
+                        self._prediction_error_labels[detect_index] = ErrorLabelType.CLASS_NAME
+                    elif (gt_is_matched[gt_index] is not None):
+                        # todo - check if should use conf score or iou score
+                        if gt_is_matched[gt_index][0] <= iou_score:
+                            # reset previously correct match
+                            # todo - fix this so choose one w higher conf score to be consistent w MAP and NMS algorithsm 
+                            matched = True 
+                            prev_correct_match_index = gt_is_matched[gt_index][1]
+                            gt_is_matched[prev_correct_match_index] = -1 # todo check this
+                            gt_is_matched[gt_index] = (iou_score, detect_index)
+                            self._prediction_error_labels[detect_index] = ErrorLabelType.DUPLICATE_DETECTION
+                    else:
+                        # this means bbs overlap, class names = (1st time)
+                        matched = True
+                        gt_is_matched[gt_index] = (iou_score, detect_index)
+                        break
+            if not matched:
+                if background:
+                    self._prediction_error_labels[detect_index] = ErrorLabelType.BACKGROUND
+                else:
+                    # if detect[0] 
+                    self._prediction_error_labels[detect_index] = ErrorLabelType.BOTH
+
+        for gt_index in range(len(self._true_y)):
+            gt = self._true_y[gt_index]
+            if gt is None:
+                self._missing_labels[gt_index] = ErrorLabelType.MISSING

--- a/python/vision_explanation_methods/error_labeling/error_labeling.py
+++ b/python/vision_explanation_methods/error_labeling/error_labeling.py
@@ -50,7 +50,6 @@ class ErrorLabeling():
     """
 
     def __init__(self,
-                 task_type: str,
                  pred_y: str,
                  true_y: str,
                  iou_threshold: float = 0.5):
@@ -66,20 +65,9 @@ class ErrorLabeling():
         :type evaluation_examples: pandas.DataFrame
         :param target_column: The name of the label column.
         :type target_column: str
-        :param task_type: The task to run.
-        :type task_type: str
-        :param classes: Class names as a list of strings.
-            The order of the class names should match that of the model
-            output. Only required if explaining classifier.
-        :type classes: list
-        :param image_mode: The mode to open the image in.
-            See pillow documentation for all modes:
-            https://pillow.readthedocs.io/en/stable/handbook/concepts.html
-        :type image_mode: str
         """
         self._is_run = False
         self._is_added = False
-        self._task_type = task_type
         self._pred_y = pred_y
         self._true_y = true_y
         self._iou_threshold = iou_threshold

--- a/python/vision_explanation_methods/error_labeling/error_labeling.py
+++ b/python/vision_explanation_methods/error_labeling/error_labeling.py
@@ -44,6 +44,7 @@ class ErrorLabelType(Enum):
 
 class ErrorLabeling():
     """Defines a wrapper class of Error Labeling for vision scenario.
+
     Only supported for object detection at this point.
     """
 

--- a/python/vision_explanation_methods/error_labeling/error_labeling.py
+++ b/python/vision_explanation_methods/error_labeling/error_labeling.py
@@ -94,39 +94,34 @@ class ErrorLabeling():
         sorted_list = sorted(self._pred_y, key=lambda x: x[-1], reverse=True)
 
         for gt_index, gt in enumerate(self._true_y):
+            print((self._match_matrix))
             for detect_index, detect in enumerate(sorted_list):
                 iou_score = torchvision.ops.box_iou(
                     Tensor(detect[1:5]).unsqueeze(0).view(-1, 4),
                     Tensor(gt[1:5]).unsqueeze(0).view(-1, 4))
                 if iou_score.item() == 0.0:
                     self._match_matrix[gt_index][detect_index] = ErrorLabelType.BACKGROUND
-                    self._match_matrix[gt_index] = [self._match_matrix[gt_index][i] for i in original_indices]
                     continue
                 if (self._iou_threshold <= iou_score):
                     # the detection and ground truth bb's must be overlapping
                     if detect[0] != gt[0]:
                         # the bb's line up, but labels do not
                         self._match_matrix[gt_index][detect_index] = ErrorLabelType.CLASS_NAME
-                        self._match_matrix[gt_index] = [self._match_matrix[gt_index][i] for i in original_indices]
                         continue
                     elif (ErrorLabelType.MATCH in
                           self._match_matrix[gt_index]):
                         self._match_matrix[gt_index][detect_index] = ErrorLabelType.DUPLICATE_DETECTION
-                        self._match_matrix[gt_index] = [self._match_matrix[gt_index][i] for i in original_indices]
                         continue
                     else:
                         # this means bbs overlap, class names = (1st time)
                         self._match_matrix[gt_index][detect_index] = ErrorLabelType.MATCH
-                        self._match_matrix[gt_index] = [self._match_matrix[gt_index][i] for i in original_indices]
                         continue
                 else:
                     if detect[0] != gt[0]:
                         # the bb's don't line up, but labels do not
                         self._match_matrix[gt_index][detect_index] = ErrorLabelType.BOTH
-                        self._match_matrix[gt_index] = [self._match_matrix[gt_index][i] for i in original_indices]
                         continue
                     else:
                         self._match_matrix[gt_index][detect_index] = ErrorLabelType.LOCALIZATION
-                        self._match_matrix[gt_index] = [self._match_matrix[gt_index][i] for i in original_indices]
                         continue
-        print((self._match_matrix))
+            self._match_matrix[gt_index] = [self._match_matrix[gt_index][i] for i in original_indices]

--- a/python/vision_explanation_methods/error_labeling/error_labeling.py
+++ b/python/vision_explanation_methods/error_labeling/error_labeling.py
@@ -79,7 +79,8 @@ class ErrorLabeling():
         self._pred_y = pred_y
         self._true_y = true_y
         self._iou_threshold = iou_threshold
-        self._match_matrix = np.full((len(self._true_y), len(self._pred_y)), None)
+        self._match_matrix = np.full((len(self._true_y), len(self._pred_y)),
+                                     None)
 
     def compute(self, **kwargs):
         """Compute the error analysis data.
@@ -88,7 +89,9 @@ class ErrorLabeling():
             Note that this method does not take any arguments currently.
         :type kwargs: dict
         """
-        original_indices = [i for i, _ in sorted(enumerate(self._pred_y), key=lambda x: x[1][-1], reverse=True)]
+        original_indices = [i for i, _ in sorted(enumerate(self._pred_y),
+                                                 key=lambda x: x[1][-1],
+                                                 reverse=True)]
 
         # sort predictions by decreasing conf score
         sorted_list = sorted(self._pred_y, key=lambda x: x[-1], reverse=True)
@@ -100,28 +103,35 @@ class ErrorLabeling():
                     Tensor(detect[1:5]).unsqueeze(0).view(-1, 4),
                     Tensor(gt[1:5]).unsqueeze(0).view(-1, 4))
                 if iou_score.item() == 0.0:
-                    self._match_matrix[gt_index][detect_index] = ErrorLabelType.BACKGROUND
+                    self._match_matrix[gt_index][detect_index] = (
+                        ErrorLabelType.BACKGROUND)
                     continue
                 if (self._iou_threshold <= iou_score):
                     # the detection and ground truth bb's must be overlapping
                     if detect[0] != gt[0]:
                         # the bb's line up, but labels do not
-                        self._match_matrix[gt_index][detect_index] = ErrorLabelType.CLASS_NAME
+                        self._match_matrix[gt_index][detect_index] = (
+                            ErrorLabelType.CLASS_NAME)
                         continue
                     elif (ErrorLabelType.MATCH in
                           self._match_matrix[gt_index]):
-                        self._match_matrix[gt_index][detect_index] = ErrorLabelType.DUPLICATE_DETECTION
+                        self._match_matrix[gt_index][detect_index] = (
+                            ErrorLabelType.DUPLICATE_DETECTION)
                         continue
                     else:
                         # this means bbs overlap, class names = (1st time)
-                        self._match_matrix[gt_index][detect_index] = ErrorLabelType.MATCH
+                        self._match_matrix[gt_index][detect_index] = (
+                            ErrorLabelType.MATCH)
                         continue
                 else:
                     if detect[0] != gt[0]:
                         # the bb's don't line up, but labels do not
-                        self._match_matrix[gt_index][detect_index] = ErrorLabelType.BOTH
+                        self._match_matrix[gt_index][detect_index] = (
+                            ErrorLabelType.BOTH)
                         continue
                     else:
-                        self._match_matrix[gt_index][detect_index] = ErrorLabelType.LOCALIZATION
+                        self._match_matrix[gt_index][detect_index] = (
+                            ErrorLabelType.LOCALIZATION)
                         continue
-            self._match_matrix[gt_index] = [self._match_matrix[gt_index][i] for i in original_indices]
+            self._match_matrix[gt_index] = [self._match_matrix[gt_index][i]
+                                            for i in original_indices]

--- a/python/vision_explanation_methods/error_labeling/error_labeling.py
+++ b/python/vision_explanation_methods/error_labeling/error_labeling.py
@@ -24,6 +24,7 @@ class ErrorLabelType(Enum):
     MISSING = "missing"
 
     # the model predicted detections, but there was nothing there
+    # this prediction must have a 0 iou score with all gt detections
     BACKGROUND = "background"
 
     # the predicted class is correct, bounding box is not
@@ -33,7 +34,7 @@ class ErrorLabelType(Enum):
     CLASS_NAME = "class_name"
 
     # both the predicted class and bounding box are incorrect
-    BOTH = "both"
+    CLASS_LOCALIZATION = "class_localization"
 
     # the predicted class is correct, the bounding box is correct, but
     # the iou score is lower than another detection
@@ -130,7 +131,7 @@ class ErrorLabeling():
                     if detect[0] != gt[0]:
                         # the bb's don't line up, but labels do not
                         self._match_matrix[gt_index][detect_index] = (
-                            ErrorLabelType.BOTH)
+                            ErrorLabelType.CLASS_LOCALIZATION)
                         continue
                     else:
                         self._match_matrix[gt_index][detect_index] = (

--- a/python/vision_explanation_methods/error_labeling/error_labeling.py
+++ b/python/vision_explanation_methods/error_labeling/error_labeling.py
@@ -19,6 +19,7 @@ class ErrorLabelType(Enum):
     If none, then the detection is not an error. It is a
     correct prediction.
     """
+
     # the gt doesn't have a corresponding detection
     MISSING = "missing"
 
@@ -45,12 +46,13 @@ class ErrorLabeling():
     """Defines a wrapper class of Error Labeling for vision scenario.
     Only supported for object detection at this point.
     """
+
     def __init__(self,
                  task_type: str,
                  pred_y: str,
                  true_y: str,
                  iou_threshold: float = 0.5):
-        """Creates an ErrorLabeling object.
+        """Create an ErrorLabeling object.
 
         :param model: The model to explain.
             A model that implements sklearn.predict or sklearn.predict_proba

--- a/python/vision_explanation_methods/error_labeling/error_labeling.py
+++ b/python/vision_explanation_methods/error_labeling/error_labeling.py
@@ -3,11 +3,11 @@
 
 """Defines the Error Labeling Manager class."""
 
-import torchvision
-from torch import Tensor
+from enum import Enum
 
 import numpy as np
-from enum import Enum
+import torchvision
+from torch import Tensor
 
 LABELS = 'labels'
 

--- a/python/vision_explanation_methods/error_labeling/error_labeling.py
+++ b/python/vision_explanation_methods/error_labeling/error_labeling.py
@@ -89,6 +89,9 @@ class ErrorLabeling():
     def compute(self, **kwargs):
         """Compute the error analysis data.
 
+        Note: if a row does not have a match, that means that there is a
+        missing gt detection
+
         :param kwargs: The keyword arguments to pass to the compute method.
             Note that this method does not take any arguments currently.
         :type kwargs: dict

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -108,6 +108,12 @@ class TestErrorLabelingManager(object):
          [[0, 1, 1, 20, 20, 0]],
          .5,
          np.array([None])),
+
+        # edge case for background error (bb's touch, but iou is 0)
+        ([[44, 5, 5, 1, 1, 0]],
+         [[44, 6, 6, 1, 1, 0]],
+         .5,
+         np.array([ErrorLabelType.BACKGROUND])),
     ])
     def test_object_detection_image_labeling(self,
                                              pred_y,
@@ -122,8 +128,3 @@ class TestErrorLabelingManager(object):
                             iou_threshold)
         mng.compute()
         assert (mng._match_matrix == result).all()
-
-
-# TestErrorLabeling().test_object_detection_image_labeling(
-# [[1, 50, 50, 100, 100, 0]],
-#  [[1, 350, 350, 100, 100, 0]],.5,[None, None])

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -26,6 +26,14 @@ class TestErrorLabelingManager(object):
          [np.array([ErrorLabelType.MATCH, ErrorLabelType.BACKGROUND]),
           np.array([ErrorLabelType.BACKGROUND, ErrorLabelType.MATCH])]),
 
+        # correct instance, predictions exactly the same for multiple detects
+        # order is mixed up
+        ([[44, 5, 5, 7, 7, 0], [44, 1, 1, 2, 2, 0]],
+         [[44, 1, 1, 2, 2, 0], [44, 5, 5, 7, 7, 0]],
+         .5,
+         [np.array([ErrorLabelType.BACKGROUND, ErrorLabelType.MATCH]),
+          np.array([ErrorLabelType.MATCH, ErrorLabelType.BACKGROUND])]),
+
         # correct instance, prediction not = but w/in iou threshold
         ([[44, 162, 65, 365, 660, 0]],
          [[44, 162, 65, 365, 670, 0]],
@@ -44,7 +52,7 @@ class TestErrorLabelingManager(object):
          .5,
          np.array([ErrorLabelType.CLASS_NAME])),
 
-        # complete miss, minor overlap with original ,
+        # complete miss, minor overlap with original (less than iou)
         ([[1, 162, 65, 1000, 1000, 0]],
          [[2, 162, 65, 1000, 200, 0]],
          .5,
@@ -64,7 +72,7 @@ class TestErrorLabelingManager(object):
          np.array([ErrorLabelType.MATCH, ErrorLabelType.DUPLICATE_DETECTION])),
 
         # duplicate detection, detections not identical but w/in iou range.
-        # Detection with lower iou has diff conf score
+        # Detection with lower iou has higher conf score
         ([[1, 162, 65, 365, 660, 0], [1, 162, 65, 365, 659, 50]],
          [[1, 162, 65, 365, 660, 0]],
          .5,

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -4,7 +4,6 @@
 import numpy as np
 import pytest
 
-from responsibleai_vision import ModelTask
 from vision_explanation_methods.error_labeling.error_labeling import (
     ErrorLabelType, ErrorLabeling)
 
@@ -105,7 +104,7 @@ class TestErrorLabelingManager(object):
                                              true_y,
                                              iou_threshold,
                                              result):
-        task_type = ModelTask.OBJECT_DETECTION
+        task_type = 'object_detection'
         mng = ErrorLabeling(task_type,
                             pred_y,
                             true_y,

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -121,7 +121,6 @@ class TestErrorLabelingManager(object):
                             true_y,
                             iou_threshold)
         mng.compute()
-        print(mng._match_matrix)
         assert (mng._match_matrix == result).all()
 
 

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -48,7 +48,7 @@ class TestErrorLabelingManager(object):
         ([[1, 162, 65, 1000, 1000, 0]],
          [[2, 162, 65, 1000, 200, 0]],
          .5,
-         np.array([ErrorLabelType.BOTH])),
+         np.array([ErrorLabelType.CLASS_LOCALIZATION])),
 
         # duplicate detection,
         ([[1, 162, 65, 365, 660, 0], [1, 162, 65, 365, 660, 0]],

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -11,11 +11,9 @@ from vision_explanation_methods.error_labeling.error_labeling import (
 
 
 class TestErrorLabelingManager(object):
-    """
-    Testing error_labeling.py
-    """
+    """Testing error_labeling.py."""
 
-    @pytest.mark.parametrize(("pred_y, true_y, iou_threshold, result"), [
+    @pytest.mark.parametrize(("pred_y", "true_y", "iou_threshold", "result"), [
         # correct instance, prediction exactly the same
         ([[44, 162, 65, 365, 660, 0]],
          [[44, 162, 65, 365, 660, 0]],
@@ -109,9 +107,7 @@ class TestErrorLabelingManager(object):
                                              true_y,
                                              iou_threshold,
                                              result):
-        """
-        Compare _match_matrix attribute to expected result
-        """
+        """Compare _match_matrix attribute to expected result."""
         task_type = 'object_detection'
         mng = ErrorLabeling(task_type,
                             pred_y,

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import pytest
+
+from responsibleai_vision import ModelTask
+from vision_explanation_methods.error_labeling import (
+    ErrorLabelType, ErrorLabeling)
+
+
+class TestErrorLabelingManager(object):
+
+    @pytest.mark.parametrize("pred_y, true_y, iou_threshold, result, result_missing", [
+        # correct instance, prediction exactly the same
+        ([[44, 162, 65, 365, 660, 0]],
+         [[44, 162, 65, 365, 660, 0]],
+         .5,
+         [None],
+         [None]),
+
+        # correct instance, predictions exactly the same for multiple detects
+        ([[44, 162, 65, 365, 660, 0], [44, 1, 4, 7, 10, 0]],
+         [[44, 162, 65, 365, 660, 0], [44, 1, 4, 7, 10, 0]],
+         .5,
+         [None, None],
+         [None, None]),
+
+        # correct instance, prediction not = but w/in iou threshold
+        ([[44, 162, 65, 365, 660, 0]],
+         [[44, 162, 65, 365, 670, 0]],
+         .5,
+         [None],
+         [None]),
+
+        # class error
+        ([[44, 162, 65, 365, 660, 0]],
+         [[1, 162, 65, 365, 660, 0]],
+         .5,
+         [ErrorLabelType.CLASS_NAME],
+         [None]),
+
+        # complete miss, minor overlap with original 5, 660, 0]],
+         [[1, 162, 65, 1000, 1000, 0]],
+         .5,
+         [ErrorLabelType.BOTH],
+         [None]),
+
+        # duplicate detection, 
+        ([[1, 162, 65, 365, 660, 0], [1, 162, 65, 365, 660, 0]],
+         [[1, 162, 65, 365, 660, 0]],
+         .5,
+         [None, ErrorLabelType.DUPLICATE_DETECTION],
+         [None]),
+
+        # duplicate detection, detections not identical but w/in iou range
+        ([[1, 162, 65, 365, 660, 0], [1, 162, 65, 365, 659, 0]],
+         [[1, 162, 65, 365, 660, 0]],
+         .5,
+         [None, ErrorLabelType.DUPLICATE_DETECTION],
+         [None]),
+
+        # background error with same class
+        ([[1, 50, 50, 100, 100, 0]],
+         [[1, 350, 350, 100, 100, 0]],
+         .5,
+         [ErrorLabelType.BACKGROUND],
+         [ErrorLabelType.MISSING]),
+
+        # background error with different class
+        ([[0, 50, 50, 100, 100, 0]],
+         [[1, 350, 350, 100, 100, 0]],
+         .5,
+         [ErrorLabelType.BACKGROUND],
+         [ErrorLabelType.MISSING]),
+
+        # complete miss
+        ([[0, 1, 1, 20, 20, 0]],
+         [[1, 19, 19, 10, 10, 0]],
+         .5,
+         [ErrorLabelType.BOTH],
+         [ErrorLabelType.MISSING]),
+    ])
+    def test_object_detection_image_labeling(self,
+                                             pred_y,
+                                             true_y,
+                                             iou_threshold,
+                                             result,
+                                             result_missing):
+        task_type = ModelTask.OBJECT_DETECTION
+        mng = ErrorLabeling(task_type,
+                                   pred_y,
+                                   true_y,
+                                   iou_threshold)
+        mng.compute()
+        assert mng._prediction_error_labels == result
+        assert mng._missing_labels == result_missing
+
+
+# TestErrorLabeling().test_object_detection_image_labeling([[1, 50, 50, 100, 100, 0]],
+#          [[1, 350, 350, 100, 100, 0]],.5,[None, None])

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -55,7 +55,8 @@ class TestErrorLabelingManager(object):
          .5,
          np.array([ErrorLabelType.MATCH, ErrorLabelType.DUPLICATE_DETECTION])),
 
-        # duplicate detection, detections not identical but w/in iou range. same conf score
+        # duplicate detection, detections not identical but w/in iou range.
+        # same conf score
         ([[1, 162, 65, 365, 660, 0], [1, 162, 65, 365, 659, 0]],
          [[1, 162, 65, 365, 660, 0]],
          .5,
@@ -114,5 +115,6 @@ class TestErrorLabelingManager(object):
         assert (mng._match_matrix == result).all()
 
 
-# TestErrorLabeling().test_object_detection_image_labeling([[1, 50, 50, 100, 100, 0]],
-#          [[1, 350, 350, 100, 100, 0]],.5,[None, None])
+# TestErrorLabeling().test_object_detection_image_labeling(
+# [[1, 50, 50, 100, 100, 0]],
+#  [[1, 350, 350, 100, 100, 0]],.5,[None, None])

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -34,6 +34,13 @@ class TestErrorLabelingManager(object):
          [np.array([ErrorLabelType.BACKGROUND, ErrorLabelType.MATCH]),
           np.array([ErrorLabelType.MATCH, ErrorLabelType.BACKGROUND])]),
 
+        # missing detection
+        ([[44, 5, 5, 7, 7, 0]],
+         [[44, 1, 1, 2, 2, 0], [44, 5, 5, 7, 7, 0]],
+         .5,
+         [np.array([ErrorLabelType.BACKGROUND]),
+          np.array([ErrorLabelType.MATCH])]),
+
         # correct instance, prediction not = but w/in iou threshold
         ([[44, 162, 65, 365, 660, 0]],
          [[44, 162, 65, 365, 670, 0]],
@@ -127,4 +134,5 @@ class TestErrorLabelingManager(object):
                             true_y,
                             iou_threshold)
         mng.compute()
+        print(mng._match_matrix)
         assert (mng._match_matrix == result).all()

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -5,9 +5,8 @@
 
 import numpy as np
 import pytest
-
 from vision_explanation_methods.error_labeling.error_labeling import (
-    ErrorLabelType, ErrorLabeling)
+    ErrorLabeling, ErrorLabelType)
 
 
 class TestErrorLabelingManager(object):

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+"""Test error labeling in the vision-explanation-methods package."""
+
 import numpy as np
 import pytest
 
@@ -9,8 +11,11 @@ from vision_explanation_methods.error_labeling.error_labeling import (
 
 
 class TestErrorLabelingManager(object):
+    """
+    Testing error_labeling.py
+    """
 
-    @pytest.mark.parametrize("pred_y, true_y, iou_threshold, result", [
+    @pytest.mark.parametrize(("pred_y, true_y, iou_threshold, result"), [
         # correct instance, prediction exactly the same
         ([[44, 162, 65, 365, 660, 0]],
          [[44, 162, 65, 365, 660, 0]],
@@ -104,6 +109,9 @@ class TestErrorLabelingManager(object):
                                              true_y,
                                              iou_threshold,
                                              result):
+        """
+        Compare _match_matrix attribute to expected result
+        """
         task_type = 'object_detection'
         mng = ErrorLabeling(task_type,
                             pred_y,

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -134,5 +134,4 @@ class TestErrorLabelingManager(object):
                             true_y,
                             iou_threshold)
         mng.compute()
-        print(mng._match_matrix)
         assert (mng._match_matrix == result).all()

--- a/tests/test_error_labeling.py
+++ b/tests/test_error_labeling.py
@@ -128,9 +128,7 @@ class TestErrorLabelingManager(object):
                                              iou_threshold,
                                              result):
         """Compare _match_matrix attribute to expected result."""
-        task_type = 'object_detection'
-        mng = ErrorLabeling(task_type,
-                            pred_y,
+        mng = ErrorLabeling(pred_y,
                             true_y,
                             iou_threshold)
         mng.compute()


### PR DESCRIPTION
This PR creates a new module that will assign error labels to predicted detections. By comparing them to ground truth detections, the module creates an attribute called self._match_matrix, that saves the relationship between ground truth detection i and predicted detection j. 


Error types are based on this Git project: https://github.com/dbolya/tide/tree/master/tidecv:
<img width="511" alt="image" src="https://github.com/microsoft/vision-explanation-methods/assets/123979655/58422487-8b2f-4a88-b531-37e5cbf46be7">


Here are some examples of the matrix per image scenario:
<img width="391" alt="image" src="https://github.com/microsoft/vision-explanation-methods/assets/123979655/c0c60adc-629e-4073-9791-c632c7811281">
