### PR TITLE
add readthedocs documentation to vision-explanation-methods

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
+sphinx:
+   builder: html
+   configuration: python/docs/conf.py
+
+python:
+   install:
+   - requirements: requirements-torch.txt
+   - requirements: requirements-doc.txt
+   - method: pip
+     path: python
+
+formats:
+  - epub
+  - pdf

--- a/python/docs/api_reference.rst
+++ b/python/docs/api_reference.rst
@@ -1,0 +1,78 @@
+.. _api_reference:
+
+API Reference
+=============
+
+This section provides a detailed reference to the classes and functions in the vision-explanation-methods package.
+
+vision_explanation_methods
+--------------------------
+
+.. automodule:: vision_explanation_methods
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+vision_explanation_methods.explanations
+---------------------------------------
+
+.. automodule:: vision_explanation_methods.explanations
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+vision_explanation_methods.explanations.drise
+---------------------------------------------
+
+.. automodule:: vision_explanation_methods.explanations.drise
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+vision_explanation_methods.evaluation
+-------------------------------------
+
+.. automodule:: vision_explanation_methods.evaluation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+vision_explanation_methods.evaluation.pointing_game
+---------------------------------------------------
+
+.. automodule:: vision_explanation_methods.evaluation.pointing_game
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+vision_explanation_methods.error_labeling
+-----------------------------------------
+
+.. automodule:: vision_explanation_methods.error_labeling
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+vision_explanation_methods.error_labeling.error_labeling
+--------------------------------------------------------
+
+.. automodule:: vision_explanation_methods.error_labeling.error_labeling
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+vision_explanation_methods.DRISE_runner
+----------------------------------------
+
+.. automodule:: vision_explanation_methods.DRISE_runner
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+vision_explanation_methods.version
+----------------------------------
+
+.. automodule:: vision_explanation_methods.version
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/code_of_conduct.rst
+++ b/python/docs/code_of_conduct.rst
@@ -1,0 +1,12 @@
+.. _code_of_conduct:
+
+Microsoft Open Source Code of Conduct
+=====================================
+
+This project has adopted the `Microsoft Open Source Code of Conduct <https://opensource.microsoft.com/codeofconduct/>`_.
+
+Resources:
+
+- `Microsoft Open Source Code of Conduct <https://opensource.microsoft.com/codeofconduct/>`_
+- `Microsoft Code of Conduct FAQ <https://opensource.microsoft.com/codeofconduct/faq/>`_
+- Contact `opencode@microsoft.com <mailto:opencode@microsoft.com>`_ with questions or concerns

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -1,0 +1,63 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Configuration file for the Sphinx documentation builder."""
+
+# -- Path setup --------------------------------------------------------------
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../../'))
+
+# -- Project information -----------------------------------------------------
+
+project = 'vision-explanation-methods'
+author = 'Microsoft Corporation'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.7'
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.intersphinx',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# -- Extension configuration -------------------------------------------------
+
+# -- Options for intersphinx extension ---------------------------------------
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {'https://docs.python.org/': None}

--- a/python/docs/contributing.rst
+++ b/python/docs/contributing.rst
@@ -1,0 +1,22 @@
+.. _contributing:
+
+Contributing to vision-explanation-methods
+==========================================
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the `Microsoft Open Source Code of Conduct <https://opensource.microsoft.com/codeofconduct/>`_. For more information see the `Code of Conduct FAQ <https://opensource.microsoft.com/codeofconduct/faq/>`_ or contact `opencode@microsoft.com <mailto:opencode@microsoft.com>`_ with any additional questions or comments.
+
+Trademarks
+----------
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow `Microsoft's Trademark & Brand Guidelines <https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general>`_. Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+Security
+--------
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations. If you believe you have found a security vulnerability in any Microsoft-owned repository that meets `Microsoft's definition of a security vulnerability <https://aka.ms/opensource/security/definition>`_, please report it to us as described below.
+
+Please do not report security vulnerabilities through public GitHub issues. Instead, please report them to the Microsoft Security Response Center (MSRC) at `https://msrc.microsoft.com/create-report <https://aka.ms/opensource/security/create-report>`_. If you prefer to submit without logging in, send email to `secure@microsoft.com <mailto:secure@microsoft.com>`_. If possible, encrypt your message with our PGP key; please download it from the `Microsoft Security Response Center PGP Key page <https://aka.ms/opensource/security/pgpkey>`_.
+
+Microsoft follows the principle of `Coordinated Vulnerability Disclosure <https://aka.ms/opensource/security/cvd>`_.

--- a/python/docs/error_labeling.rst
+++ b/python/docs/error_labeling.rst
@@ -1,0 +1,49 @@
+.. _error_labeling:
+
+Error Labeling
+==============
+
+The Error Labeling Manager class is defined in the ``error_labeling.py`` file in the ``vision_explanation_methods/error_labeling`` directory. This class is used to label errors in the vision-explanation-methods package.
+
+Error Labeling Manager Class
+----------------------------
+
+The Error Labeling Manager class is used to label errors in the vision-explanation-methods package. It uses the Intersection over Union (IoU) threshold to determine the overlap between the predicted and true bounding boxes. The class also uses the ErrorLabelType Enum to define the types of error labels.
+
+The ErrorLabelType Enum provides the following types of error labels:
+
+- MISSING: The ground truth doesn't have a corresponding detection.
+- BACKGROUND: The model predicted detections, but there was nothing there. This prediction must have a 0 IoU score with all ground truth detections.
+- LOCALIZATION: The predicted class is correct, but the bounding box does not have sufficient overlap with the ground truth (based on the IoU threshold).
+- CLASS_NAME: The predicted class is incorrect, but the bounding box is correct.
+- CLASS_LOCALIZATION: Both the predicted class and bounding box are incorrect.
+- DUPLICATE_DETECTION: The predicted class is correct, the bounding box is correct, but the IoU score is lower than another detection.
+- MATCH: The bounding boxes overlap and the class names match.
+
+The Error Labeling Manager class provides the following methods:
+
+- ``compute_error_labels()``: This method computes the error labels for the predicted and true bounding boxes.
+- ``compute_error_list()``: This method determines a complete list of errors encountered during prediction.
+
+Error Labeling in Object Detection
+-----------------------------------
+
+In object detection, the Error Labeling Manager class is used to label errors in the predictions. The class uses the IoU threshold to determine the overlap between the predicted and true bounding boxes. The class also uses the ErrorLabelType Enum to define the types of error labels.
+
+The ErrorLabelType Enum provides the following types of error labels:
+
+- MISSING: The ground truth doesn't have a corresponding detection.
+- BACKGROUND: The model predicted detections, but there was nothing there. This prediction must have a 0 IoU score with all ground truth detections.
+- LOCALIZATION: The predicted class is correct, but the bounding box does not have sufficient overlap with the ground truth (based on the IoU threshold).
+- CLASS_NAME: The predicted class is incorrect, but the bounding box is correct.
+- CLASS_LOCALIZATION: Both the predicted class and bounding box are incorrect.
+- DUPLICATE_DETECTION: The predicted class is correct, the bounding box is correct, but the IoU score is lower than another detection.
+- MATCH: The bounding boxes overlap and the class names match.
+
+The Error Labeling Manager class provides the following methods:
+
+- ``compute_error_labels()``: This method computes the error labels for the predicted and true bounding boxes.
+- ``compute_error_list()``: This method determines a complete list of errors encountered during prediction.
+
+.. note::
+   The Error Labeling Manager class is used in the ``test_error_labeling.py`` file in the ``tests`` directory to test the error labeling in the vision-explanation-methods package.

--- a/python/docs/generating_saliency_maps.rst
+++ b/python/docs/generating_saliency_maps.rst
@@ -1,0 +1,41 @@
+.. _generating_saliency_maps:
+
+Generating Saliency Maps for Object Detection Models
+====================================================
+
+This section provides an overview of the methods used to generate saliency maps for object detection models in the vision-explanation-methods package.
+
+DRISE_runner.py
+----------------
+
+The DRISE_runner.py file contains the main function for generating saliency maps, `get_drise_saliency_map()`. This function takes in an image, a model, the number of classes, and a save name as parameters. It also accepts optional parameters for the number of masks, mask resolution, mask padding, device choice, and maximum figures.
+
+The function begins by setting the device to either CUDA or CPU, depending on the availability of a GPU. If a model is not provided, the function loads a pre-trained Faster R-CNN model with a ResNet50 backbone. The image is then converted to a tensor and passed to the model for prediction.
+
+The function then generates saliency scores using the DRISE method. The saliency scores are filtered to remove any scores containing NaN values. If no detections are found, the function raises a ValueError.
+
+The function then generates a list of labels and a list of figures for each detection. Each figure is a visualization of the saliency map for the corresponding detection. The figures are saved as JPEG images and returned as base64 strings.
+
+The function finally returns a tuple containing the list of figures, the save name, and the list of labels.
+
+DRISE_saliency()
+----------------
+
+The `DRISE_saliency()` function in the drise.py file is used to compute the DRISE saliency map. This function takes in a model, an image tensor, target detections, and the number of masks as parameters. It also accepts optional parameters for mask resolution, mask padding, device, and verbosity.
+
+The function begins by setting the mask padding and generating a list of mask records. Each mask record contains a mask and a list of affinity scores. The affinity scores are computed by comparing the target detections with the detections made on the masked image.
+
+The function then fuses the masks based on their affinity scores to generate the saliency map.
+
+PointingGame Class
+------------------
+
+The PointingGame class in the pointing_game.py file provides methods for evaluating the saliency maps. The `pointing_game()` method calculates the saliency scores for a given object detection prediction. The `calculate_gt_salient_pixel_overlap()` method calculates the overlap between the salient pixels and the ground truth bounding box.
+
+Error Labeling
+--------------
+
+The error_labeling.py file provides methods for labeling the errors in the object detection predictions. The `ErrorLabelingManager` class manages the error labeling process. The `label_errors()` method labels the errors based on the intersection over union (IoU) scores between the ground truth and predicted bounding boxes.
+
+.. note::
+   The vision-explanation-methods package uses the DRISE method for generating saliency maps. DRISE is a black box explainability method for object detection models. It generates saliency maps by occluding parts of the image with random masks and observing the effect on the model's predictions.

--- a/python/docs/getting_started.rst
+++ b/python/docs/getting_started.rst
@@ -1,0 +1,50 @@
+# Getting Started with vision-explanation-methods
+
+This documentation provides a guide on how to get started with the vision-explanation-methods package. 
+
+## Installation
+
+To install the vision-explanation-methods package, you need to run the setup file. The setup file for the vision-explanation-methods package is located at `python/setup.py`. This file contains metadata including the name and version of the package. 
+
+The dependencies required for the package are listed in the setup file. These include:
+
+- numpy
+- tqdm
+- matplotlib<3.7.0
+- ml_wrappers
+
+To install the package, navigate to the directory containing the setup file and run the following command:
+
+```bash
+python setup.py install
+```
+
+## Usage
+
+The vision-explanation-methods package provides a variety of explanation evaluation tools for image explanation methods. 
+
+### Generating Saliency Maps
+
+The `DRISE_runner.py` file contains the method for generating saliency maps for object detection models. The `get_drise_saliency_map` function is used to generate the saliency map. This function takes in parameters such as the image location, model, number of classes, save name, and maximum figures. 
+
+The function returns a tuple of figure, location, and labels. The figure is a list of base64 encoded strings representing the saliency maps. The location is the path where the saliency maps are saved. The labels are a list of labels for the detected objects.
+
+### Error Labeling
+
+The `error_labeling.py` file defines the Error Labeling Manager class. This class is used to label errors in the predictions of the model. The types of errors that can be labeled include class name errors, duplicate detection errors, background errors, and missing detection errors.
+
+## Contributing
+
+Contributions to the vision-explanation-methods package are welcome. Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute to the project.
+
+## Code of Conduct
+
+The vision-explanation-methods package has adopted the Microsoft Open Source Code of Conduct. Please refer to the `CODE_OF_CONDUCT.md` file for more information.
+
+## Support
+
+For help and questions about using the vision-explanation-methods package, please refer to the `SUPPORT.md` file. This file provides information on how to file issues and get help.
+
+## License
+
+The vision-explanation-methods package is licensed under the MIT License. Please refer to the `LICENSE.txt` file for more information.

--- a/python/docs/index.rst
+++ b/python/docs/index.rst
@@ -1,0 +1,27 @@
+.. _index:
+
+=============================
+Vision Explanation Methods
+=============================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   overview
+   getting_started
+   supported_models_and_dependencies
+   contributing
+   code_of_conduct
+   error_labeling
+   generating_saliency_maps
+   using_drise
+   setup_and_installation
+   api_reference
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/python/docs/overview.rst
+++ b/python/docs/overview.rst
@@ -1,0 +1,20 @@
+.. _overview:
+
+Overview
+========
+
+The vision-explanation-methods repository provides a set of tools and methods for generating saliency maps for object detection models, evaluating explanations, and error labeling. 
+
+The repository includes the following main components:
+
+- **DRISE Runner**: This module provides a method for generating saliency maps for object detection models. It uses the DRISE (Detection-based Rise) method to generate saliency maps for a given image and model. The generated saliency maps can be used to understand which parts of the image are most important for the model's predictions.
+
+- **Pointing Game**: This module provides a variety of explanation evaluation tools. It includes a method for visualizing highly salient pixels and calculating the overlap between salient pixels and ground truth bounding boxes.
+
+- **Error Labeling**: This module provides a class for error labeling in object detection models. It includes methods for calculating Intersection over Union (IoU) scores and assigning error labels based on the IoU scores and class labels.
+
+- **Setup**: The setup file for the vision-explanation-methods package includes the package metadata and dependencies.
+
+The repository also includes a set of guidelines for contributing to the project, a code of conduct, and a license file.
+
+For more detailed information about each component and how to use them, please refer to the respective sections in the documentation.

--- a/python/docs/setup_and_installation.rst
+++ b/python/docs/setup_and_installation.rst
@@ -1,0 +1,68 @@
+.. _setup_and_installation:
+
+Setup and Installation
+======================
+
+The vision-explanation-methods package is a Python package developed by Microsoft Corporation. It provides a set of tools for explaining vision models, particularly object detection models.
+
+Installation
+------------
+
+The package can be installed using pip. The dependencies required for the package are:
+
+- numpy
+- tqdm
+- matplotlib<3.7.0
+- ml_wrappers
+
+You can install the package and its dependencies using the following command:
+
+.. code-block:: bash
+
+    pip install vision-explanation-methods
+
+Setup
+-----
+
+The setup file for the package is located at `python/setup.py`. This file contains the necessary information for the package setup, including the package name, version, description, author, license, and dependencies.
+
+The package version is defined in the `vision_explanation_methods/version.py` file. The current version of the package is 0.0.7.
+
+The package includes a README file (`README.md`) and a license file (`LICENSE.txt`). If the `LICENSE` file exists in the parent directory, it will be copied to `LICENSE.txt` during the setup process.
+
+The package is classified under the following categories:
+
+- Development Status :: 5 - Production/Stable
+- Intended Audience :: Developers
+- Intended Audience :: Science/Research
+- License :: OSI Approved :: MIT License
+- Programming Language :: Python :: 3
+- Programming Language :: Python :: 3.7
+- Programming Language :: Python :: 3.8
+- Programming Language :: Python :: 3.9
+- Topic :: Scientific/Engineering :: Artificial Intelligence
+- Operating System :: Microsoft :: Windows
+- Operating System :: MacOS
+- Operating System :: POSIX :: Linux
+
+The package is not safe for zipping.
+
+Bug Reporting
+-------------
+
+If you encounter any bugs while using the package, you can report them using the bug report template provided in the `.github/ISSUE_TEMPLATE/bug_report.md` file. Please provide a clear and concise description of the bug, steps to reproduce the behavior, the expected behavior, and any relevant screenshots or additional context. Include information about your operating system, browser, Python version, and the version of the vision-explanation-methods package.
+
+Feature Requests
+----------------
+
+If you have any suggestions for new features, you can submit them using the feature request template provided in the `.github/ISSUE_TEMPLATE/feature_request.md` file. Please provide a clear and concise description of the feature you want, any alternative solutions or features you've considered, and any additional context or screenshots.
+
+Contributing
+------------
+
+Contributions to the package are welcome. Please refer to the `README.md` file for information on how to contribute to the project.
+
+License
+-------
+
+The package is licensed under the MIT License. The full text of the license can be found in the `LICENSE.txt` file.

--- a/python/docs/supported_models_and_dependencies.rst
+++ b/python/docs/supported_models_and_dependencies.rst
@@ -1,0 +1,52 @@
+.. _supported_models_and_dependencies:
+
+Supported Models and Dependencies
+=================================
+
+Supported Models
+----------------
+
+The vision-explanation-methods package supports the following models:
+
+- Faster R-CNN model with resnet50 backbone
+
+Dependencies
+------------
+
+The vision-explanation-methods package requires the following dependencies:
+
+- numpy
+- tqdm
+- matplotlib<3.7.0
+- ml_wrappers
+
+Testing Dependencies
+--------------------
+
+The vision-explanation-methods package requires the following dependencies for testing:
+
+- pytest
+- pytest-cov
+
+Linting Dependencies
+--------------------
+
+The vision-explanation-methods package requires the following dependencies for linting:
+
+- autopep8==1.5.3
+- flake8==4.0.1
+- flake8-bugbear==21.11.29
+- flake8-blind-except==0.1.1
+- flake8-breakpoint
+- flake8-builtins==1.5.3
+- flake8-copyright==0.2.2
+- flake8-docstrings==1.5.0
+- flake8-logging-format==0.6.0
+- flake8-pytest-style
+- flake8-rst-docstrings==0.0.13
+- isort
+
+License
+-------
+
+The vision-explanation-methods package is licensed under the MIT License.

--- a/python/docs/using_drise.rst
+++ b/python/docs/using_drise.rst
@@ -1,0 +1,36 @@
+.. _using_drise:
+
+Using DRISE for Image Explanation
+=================================
+
+DRISE is a black box explainability method for object detection. It generates saliency maps for object detection models. 
+
+The DRISE method is implemented in the ``drise.py`` file located in the ``vision_explanation_methods/explanations`` directory. 
+
+The DRISE method is used in the ``DRISE_runner.py`` file located in the ``vision_explanation_methods`` directory. 
+
+The DRISE method is used in the ``pointing_game.py`` file located in the ``vision_explanation_methods/evaluation`` directory. 
+
+DRISE Implementation
+--------------------
+
+The DRISE method is implemented in the ``drise.py`` file. The implementation includes the following functions:
+
+- ``DRISE_saliency``: This function computes the DRISE saliency map. It takes as input an object detection model, an image tensor, a list of target detections, the number of masks to use for saliency, the resolution of the mask before scale up, the amount to pad the mask before cropping, the device to use to run the function, and a boolean indicating whether to print verbose output. It returns a list of tensors, one tensor for each image. Each tensor is of shape [D, 3, W, H], and [i ,3 W, H] is the saliency map associated with detection i.
+
+- ``DRISE_saliency_for_mlflow``: This function is similar to ``DRISE_saliency``, but it is designed to work with the MLflow tracking service. It takes as input a model, an image tensor, a list of target detections, the number of masks to use for saliency, the resolution of the mask before scale up, the amount to pad the mask before cropping, the device to use to run the function, and a boolean indicating whether to print verbose output. It returns a list of tensors, one tensor for each image. Each tensor is of shape [D, 3, W, H], and [i ,3 W, H] is the saliency map associated with detection i.
+
+- ``generate_mask``: This function creates a random mask for image occlusion. It takes as input the lower resolution mask grid shape, the size of the image to be masked, and the amount to offset the mask. It returns an occlusion mask for the image, which has the same shape as the image.
+
+- ``fuse_mask``: This function masks an image tensor. It takes as input an image tensor and a mask for the image. It returns the masked image.
+
+- ``compute_affinity_scores``: This function computes the highest affinity score between two sets of detections. It takes as input a set of detections to get affinity scores for and a set of detections to score against. It returns a set of affinity scores associated with each detection.
+
+Using DRISE
+-----------
+
+The DRISE method is used in the ``DRISE_runner.py`` file. The ``get_drise_saliency_map`` function in this file runs D-RISE on an image and visualizes the saliency maps. It takes as input the path of the image location, the model to use for D-RISE, the number of classes the model predicted, the path to save the output figure, the number of masks to use for saliency, the resolution of the mask before scale up, the amount to pad the mask before cropping, the device to use, and the maximum number of figures to generate. It returns a tuple of a list of Matplotlib figures, the path to where the output figure is saved, and a list of labels.
+
+The DRISE method is also used in the ``pointing_game.py`` file. The ``PointingGame`` class in this file uses D-RISE to generate saliency maps for object detection models. The ``pointing_game`` function in this class finds saliency scores for the top 20% of salient pixels. It takes as input the filename of the image, the index of the detection to explain, the threshold for saliency, and the number of masks to use for saliency. It returns a saliency map for the image.
+
+.. note:: The DRISE method requires the PyTorch library.

--- a/python/vision_explanation_methods/error_labeling/__init__.py
+++ b/python/vision_explanation_methods/error_labeling/__init__.py
@@ -1,0 +1,5 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Module for error labeling."""

--- a/python/vision_explanation_methods/evaluation/__init__.py
+++ b/python/vision_explanation_methods/evaluation/__init__.py
@@ -1,0 +1,5 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Module for evaluation."""

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,0 +1,3 @@
+sphinx==4.3.0
+pyyaml
+captum

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,0 +1,4 @@
+torch
+torchvision
+torchaudio
+--index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

GPT4 generated readthedocs documentation for vision-explanation-methods repository.
See docs website:
https://vision-explanation-methods.readthedocs.io/en/latest/index.html

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added tests for all changes.
- [x] Documentation was updated if it was needed.
