### PR TITLE
drise optimization for mlflow models by only converting each input image once to tensor instead of for every mask

### DIFF
--- a/python/vision_explanation_methods/explanations/drise.py
+++ b/python/vision_explanation_methods/explanations/drise.py
@@ -347,15 +347,15 @@ def DRISE_saliency_for_mlflow(
     mask_iterator = tqdm.tqdm(range(number_of_masks)) if verbose \
         else range(number_of_masks)
 
+    # Currently only supports single image
+    img_tens = convert_base64_to_tensor(
+        image_tensor.loc[0, 'image'], device)
+
     for _ in mask_iterator:
         # Converts image base64 to a tensor
         # Fuses mask tensor with image tensor
         # Converts fused image tensor to base64
         mask = generate_mask(mask_res, img_size, mask_padding, device)
-
-        # Currently only supports single image
-        img_tens = convert_base64_to_tensor(
-            image_tensor.loc[0, 'image'], device)
 
         masked_image = fuse_mask(img_tens, mask)
 


### PR DESCRIPTION
## Description

drise optimization for mlflow models by only converting each input image once to tensor instead of for every mask.

Previously, we would convert the image to tensor on every mask and prediction when running drise on mlflow models.  This is actually unnecessary, since the input image does not change, and is costly.  This PR moves this conversion outside of the loop to optimize explanation runtime for mlflow models.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added tests for all changes.
- [ ] Documentation was updated if it was needed.
