### PR TITLE
Update get_drise_saliency_map function

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ The process of fine-tuning an object detection model and visualizing it through 
 To generate saliency maps, import the package and run:
 ```
 res = DRISE_runner.get_drise_saliency_map(
-    imagelocation: str,
-    model: Optional[object],    
-    numclasses: int,
-    savename: str,
-    nummasks: int=25,
-    maskres: Tuple[int, int]=(4,4),
-    maskpadding: Optional[int]=None,
-    devicechoice: Optional[str]=None,
-    wrapperchoice: Optional[object] = PytorchFasterRCNNWrapper
+    image_location: str,
+    save_name: str,
+    num_masks: int = 25,
+    mask_res: Tuple[int, int] = (4, 4),
+    model: Optional[object],
+    num_classes: Optional[int] = 87,
+    mask_padding: Optional[int] = None,
+    device_choice: Optional[str] = None,
+    max_figures: Optional[int] = None
     )
 ```
 

--- a/python/vision_explanation_methods/version.py
+++ b/python/vision_explanation_methods/version.py
@@ -3,5 +3,5 @@
 name = 'vision_explanation_methods'
 _major = '0'
 _minor = '1'
-_patch = '1'
+_patch = '2'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/tests/test_vision_explanation.py
+++ b/tests/test_vision_explanation.py
@@ -61,10 +61,9 @@ def test_vision_explain_preloaded():
     # save tested result in res
 
     # run the main function for saliency map generation
-    res = dr.get_drise_saliency_map(imagelocation=imgpath,
+    res = dr.get_drise_saliency_map(image_location=imgpath,
+                                    save_name=savepath,
                                     model=None,
-                                    numclasses=90,
-                                    savename=savepath,
                                     max_figures=2)
 
     # assert that result is a tuple of figure, location, and labels.
@@ -89,11 +88,10 @@ def test_vision_explain_preloaded():
 
     # run the main function for saliency map generation
     # in the case of just a single item in photo
-    res2 = dr.get_drise_saliency_map(imagelocation=imgpath2,
-                                     model=None,
-                                     numclasses=90,
-                                     savename=savepath2,
-                                     max_figures=2)
+    res2 = dr.get_drise_saliency_map(image_location=imgpath2,
+                                    save_name=savepath,
+                                    model=None,
+                                    max_figures=2)
 
     # assert that result is a tuple of figure, location, and labels.
     assert (len(res2) == 3)
@@ -155,10 +153,10 @@ def test_vision_explain_loadmodel(use_transforms):
         model = PytorchDRiseWrapper(model=model,
                                     number_of_classes=NUM_CLASSES)
 
-    res = dr.get_drise_saliency_map(imagelocation=imgpath,
+    res = dr.get_drise_saliency_map(image_location=imgpath,
+                                    save_name=savepath,
                                     model=model,
-                                    numclasses=NUM_CLASSES,
-                                    savename=savepath,
+                                    num_classes=NUM_CLASSES,
                                     max_figures=2)
 
     # assert that result is a tuple of figure, location, and labels.
@@ -183,11 +181,11 @@ def test_vision_explain_loadmodel(use_transforms):
 
     # run the main function for saliency map generation
     # in the case of just a single item in photo
-    res2 = dr.get_drise_saliency_map(imagelocation=imgpath2,
-                                     model=model,
-                                     numclasses=NUM_CLASSES,
-                                     savename=savepath2,
-                                     max_figures=2)
+    res2 = dr.get_drise_saliency_map(image_location=imgpath2,
+                                    save_name=savepath2,
+                                    model=model,
+                                    num_classes=NUM_CLASSES,
+                                    max_figures=2)
 
     # assert that result is a tuple of figure, location, and labels.
     assert (len(res2) == 3)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update the get_drise_saliency_map function for consistent naming convention and ordering of parameters, as well as additional behaviour for the num_classes parameter when no model is passed in.

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

As per #32, this PR includes:

- Re-ordering of optional parameters to after required parameters,
- Updating all parameters and references to use snake_case,
- Default handling of the num_classes parameter when no model is passed in i.e. default to 87 classes from the COCO dataset that the pre-trained model was trained on.

<!--- Make sure to satisfy all the criteria listed below. -->

- [X] I have updated tests for all changes.
- [X] Documentation was updated if it was needed.
